### PR TITLE
Updated dependencies to use gcc7

### DIFF
--- a/arm-elf-binutils.rb
+++ b/arm-elf-binutils.rb
@@ -7,10 +7,10 @@ class ArmElfBinutils < Formula
 
   depends_on 'gcc' => :build
   def install
-    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-6'
-    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-6'
-    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-6'
-    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-6'
+    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-7'
+    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-7'
+    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-7'
+    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-7'
 
     mkdir 'build' do
       system '../configure', '--disable-nls', '--target=x86_64-elf','--disable-werror',

--- a/arm-elf-gcc.rb
+++ b/arm-elf-gcc.rb
@@ -14,10 +14,10 @@ class ArmElfGcc < Formula
   def install
     binutils = Formula.factory 'arm-elf-binutils'
 
-    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-6'
-    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-6'
-    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-6'
-    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-6'
+    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-7'
+    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-7'
+    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-7'
+    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-7'
     ENV['PATH'] += ":#{binutils.prefix/"bin"}"
 
     mkdir 'build' do

--- a/arm-elf-gcc.rb
+++ b/arm-elf-gcc.rb
@@ -2,9 +2,9 @@ require 'formula'
 
 class ArmElfGcc < Formula
   homepage 'http://gcc.gnu.org'
-  url "http://mirror.tochlab.net/pub/gnu/gcc/gcc-6.2.0/gcc-6.2.0.tar.bz2"
-  mirror "https://ftp.gnu.org/gnu/gcc/gcc-6.2.0/gcc-6.2.0.tar.bz2"
-  sha256 "9944589fc722d3e66308c0ce5257788ebd7872982a718aa2516123940671b7c5"
+  url "http://mirror.tochlab.net/pub/gnu/gcc/gcc-7.1.0/gcc-7.1.0.tar.bz2"
+  mirror "https://ftp.gnu.org/gnu/gcc/gcc-7.1.0/gcc-7.1.0.tar.bz2"
+  sha256 "8a8136c235f64c6fef69cac0d73a46a1a09bb250776a050aec8f9fc880bebc17f"
 
   depends_on 'gmp'
   depends_on 'libmpc'

--- a/arm-elf-gdb.rb
+++ b/arm-elf-gdb.rb
@@ -9,10 +9,10 @@ class ArmElfGdb < Formula
   depends_on 'arm-elf-gcc'
 
   def install
-    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-6'
-    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-6'
-    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-6'
-    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-6'
+    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-7'
+    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-7'
+    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-7'
+    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-7'
 
     mkdir 'build' do
       system '../configure', '--target=arm-elf-eabi', "--prefix=#{prefix}" ,'--disable-werror'

--- a/i586-elf-binutils.rb
+++ b/i586-elf-binutils.rb
@@ -7,10 +7,10 @@ class I586ElfBinutils < Formula
 
   depends_on 'gcc' => :build
   def install
-    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-6'
-    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-6'
-    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-6'
-    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-6'
+    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-7'
+    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-7'
+    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-7'
+    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-7'
 
     mkdir 'build' do
       system '../configure', '--disable-nls', '--target=x86_64-elf','--disable-werror',

--- a/i586-elf-gcc.rb
+++ b/i586-elf-gcc.rb
@@ -16,10 +16,10 @@ class I586ElfGcc < Formula
     binutils = Formula.factory 'i586-elf-binutils'
 
 
-    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-6'
-    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-6'
-    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-6'
-    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-6'
+    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-7'
+    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-7'
+    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-7'
+    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-7'
     ENV['PATH'] += ":#{binutils.prefix/"bin"}"
 
     mkdir 'build' do

--- a/i586-elf-gcc.rb
+++ b/i586-elf-gcc.rb
@@ -2,9 +2,9 @@ require 'formula'
 
 class I586ElfGcc < Formula
   homepage 'http://gcc.gnu.org'
-  url "http://mirror.tochlab.net/pub/gnu/gcc/gcc-6.2.0/gcc-6.2.0.tar.bz2"
-  mirror "https://ftp.gnu.org/gnu/gcc/gcc-6.2.0/gcc-6.2.0.tar.bz2"
-  sha256 "9944589fc722d3e66308c0ce5257788ebd7872982a718aa2516123940671b7c5"
+  url "http://mirror.tochlab.net/pub/gnu/gcc/gcc-7.1.0/gcc-7.1.0.tar.bz2"
+  mirror "https://ftp.gnu.org/gnu/gcc/gcc-7.1.0/gcc-7.1.0.tar.bz2"
+  sha256 "8a8136c235f64c6fef69cac0d73a46a1a09bb250776a050aec8f9fc880bebc17f"
 
   depends_on "gmp"
   depends_on "libmpc"

--- a/i586-elf-gdb.rb
+++ b/i586-elf-gdb.rb
@@ -9,10 +9,10 @@ class I586ElfGdb < Formula
   depends_on 'i586-elf-gcc'
 
   def install
-    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-6'
-    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-6'
-    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-6'
-    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-6'
+    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-7'
+    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-7'
+    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-7'
+    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-7'
 
     mkdir 'build' do
       system '../configure', '--target=i586-elf', "--prefix=#{prefix}", "--disable-werror"

--- a/x86_64-elf-binutils.rb
+++ b/x86_64-elf-binutils.rb
@@ -7,10 +7,10 @@ class X8664ElfBinutils < Formula
 
   depends_on 'gcc' => :build
   def install
-    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-6'
-    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-6'
-    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-6'
-    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-6'
+    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-7'
+    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-7'
+    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-7'
+    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-7'
 
     mkdir 'build' do
       system '../configure', '--disable-nls', '--target=x86_64-elf','--disable-werror',

--- a/x86_64-elf-gcc.rb
+++ b/x86_64-elf-gcc.rb
@@ -2,9 +2,9 @@ require 'formula'
 
 class X8664ElfGcc < Formula
   homepage 'http://gcc.gnu.org'
-  url "http://mirror.tochlab.net/pub/gnu/gcc/gcc-6.2.0/gcc-6.2.0.tar.bz2"
-  mirror "https://ftp.gnu.org/gnu/gcc/gcc-6.2.0/gcc-6.2.0.tar.bz2"
-  sha256 "9944589fc722d3e66308c0ce5257788ebd7872982a718aa2516123940671b7c5"
+  url "http://mirror.tochlab.net/pub/gnu/gcc/gcc-7.1.0/gcc-7.1.0.tar.bz2"
+  mirror "https://ftp.gnu.org/gnu/gcc/gcc-7.1.0/gcc-7.1.0.tar.bz2"
+  sha256 "8a8136c235f64c6fef69cac0d73a46a1a09bb250776a050aec8f9fc880bebc17"
 
   depends_on "gmp"
   depends_on "libmpc"
@@ -15,10 +15,10 @@ class X8664ElfGcc < Formula
   def install
     binutils = Formula.factory 'x86_64-elf-binutils'
 
-    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-6'
-    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-6'
-    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-6'
-    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-6'
+    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-7'
+    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-7'
+    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-7'
+    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-7'
     ENV['PATH'] += ":#{binutils.prefix/"bin"}"
 
     mkdir 'build' do

--- a/x86_64-elf-gdb.rb
+++ b/x86_64-elf-gdb.rb
@@ -9,10 +9,10 @@ class X8664ElfGdb < Formula
   depends_on 'x86_64-elf-gcc'
 
   def install
-    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-6'
-    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-6'
-    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-6'
-    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-6'
+    ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-7'
+    ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-7'
+    ENV['CPP'] = '/usr/local/opt/gcc/bin/cpp-7'
+    ENV['LD'] = '/usr/local/opt/gcc/bin/gcc-7'
 
     mkdir 'build' do
       system '../configure', '--target=x86_64-pc-linux', "--prefix=#{prefix}"


### PR DESCRIPTION
If gcc 6 is not installed, homebrew installs gcc7. This causes compiling errors as the scripts look for gcc6 but cannot find it and so throws an error when it trys to build the cross compiler. This should fix the errors and stop build failings on mac.