### PR TITLE
Update deprecated Formula to Formulary.

### DIFF
--- a/arm-elf-gcc.rb
+++ b/arm-elf-gcc.rb
@@ -12,7 +12,7 @@ class ArmElfGcc < Formula
   depends_on 'arm-elf-binutils'
 
   def install
-    binutils = Formula.factory 'arm-elf-binutils'
+    binutils = Formulary.factory 'arm-elf-binutils'
 
     ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-6'
     ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-6'

--- a/i586-elf-gcc.rb
+++ b/i586-elf-gcc.rb
@@ -13,7 +13,7 @@ class I586ElfGcc < Formula
   depends_on 'i586-elf-binutils'
 
   def install
-    binutils = Formula.factory 'i586-elf-binutils'
+    binutils = Formulary.factory 'i586-elf-binutils'
 
 
     ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-6'

--- a/x86_64-elf-gcc.rb
+++ b/x86_64-elf-gcc.rb
@@ -13,7 +13,7 @@ class X8664ElfGcc < Formula
   depends_on 'x86_64-elf-binutils'
 
   def install
-    binutils = Formula.factory 'x86_64-elf-binutils'
+    binutils = Formulary.factory 'x86_64-elf-binutils'
 
     ENV['CC'] = '/usr/local/opt/gcc/bin/gcc-6'
     ENV['CXX'] = '/usr/local/opt/gcc/bin/g++-6'


### PR DESCRIPTION
This commit fixes the following warning: 
> Warning: Calling Formula.factory is deprecated!
> Use Formulary.factory instead.