### PR TITLE
depend on gcc@7 explicitly

### DIFF
--- a/arm-elf-binutils.rb
+++ b/arm-elf-binutils.rb
@@ -5,7 +5,7 @@ class ArmElfBinutils < Formula
   url 'http://ftp.gnu.org/gnu/binutils/binutils-2.27.tar.gz'
   sha256 '26253bf0f360ceeba1d9ab6965c57c6a48a01a8343382130d1ed47c468a3094f'
 
-  depends_on 'gcc' => :build
+  depends_on 'gcc@7' => :build
   def install
     ENV['CC'] = '/usr/local/opt/gcc@7/bin/gcc-7'
     ENV['CXX'] = '/usr/local/opt/gcc@7/bin/g++-7'

--- a/i586-elf-binutils.rb
+++ b/i586-elf-binutils.rb
@@ -5,7 +5,7 @@ class I586ElfBinutils < Formula
   url 'http://ftp.gnu.org/gnu/binutils/binutils-2.27.tar.gz'
   sha256 '26253bf0f360ceeba1d9ab6965c57c6a48a01a8343382130d1ed47c468a3094f'
 
-  depends_on 'gcc' => :build
+  depends_on 'gcc@7' => :build
   def install
     ENV['CC'] = '/usr/local/opt/gcc@7/bin/gcc-7'
     ENV['CXX'] = '/usr/local/opt/gcc@7/bin/g++-7'

--- a/x86_64-elf-binutils.rb
+++ b/x86_64-elf-binutils.rb
@@ -5,7 +5,7 @@ class X8664ElfBinutils < Formula
   url 'http://ftp.gnu.org/gnu/binutils/binutils-2.27.tar.gz'
   sha256 '26253bf0f360ceeba1d9ab6965c57c6a48a01a8343382130d1ed47c468a3094f'
 
-  depends_on 'gcc' => :build
+  depends_on 'gcc@7' => :build
   def install
     ENV['CC'] = '/usr/local/opt/gcc@7/bin/gcc-7'
     ENV['CXX'] = '/usr/local/opt/gcc@7/bin/g++-7'


### PR DESCRIPTION
The latest version of GCC is currently 9, so depending on gcc won't
necessarily give you a binary called /usr/local/opt/gcc@7/bin/gcc-7

We should *strictly* also list gcc@7 as a build dependency of the other packages as well, but each architecture's other packages currently depends on the relevant architecture-specific binutils package, so we currently get away with it. If you want me to write a patch to fix this too, I will.